### PR TITLE
fix: Update the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ hs_err_pid*
 
 # Other
 .idea
+/target/
+
+#Eclipse auto-generated files
+.classpath
+.project
+*core.prefs


### PR DESCRIPTION
Fixes Issue #18. Updates the .gitignore to include auto-generated files created when loading the project up as a Maven Project on the Eclipse IDE. 