### PR TITLE
fix/#36 Update Maven config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,22 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
-            <scope>src/test/java</scope>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>1.6.0-M1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.jupiter.version>5.6.0</junit.jupiter.version>
+        <junit.platform.version>1.6.0-M1</junit.platform.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -42,7 +51,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.1</version>
                     <configuration>
                         <source>1.8</source>
                     </configuration>
@@ -50,7 +59,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.0.0-M4</version>
+                    <configuration>
+                        <useFile>false</useFile>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The scope for the `junit-jupiter-engine` was incorrectly set which generated warnings while building the project, this is now fixed. Also took the time to add necessary plugins and configuration for JUnit 5 and updated to the newest version of JUnit related plugins.

This pull request includes all the changes proposed in issue #36 