### PR TITLE
refactor/#43 Removed toString for Connectors

### DIFF
--- a/src/main/java/decide/Connectors.java
+++ b/src/main/java/decide/Connectors.java
@@ -1,25 +1,5 @@
 package decide;
 
-import java.io.Serializable;
-
-public enum Connectors implements Serializable {
+public enum Connectors {
     NOTUSED, ORR, ANDD;
-
-    /**
-     * Returns the {@code String} representation of the enums. The function throws {@code IllegalArgumentException} if
-     * it could not match the enum with a {@code String} representation.
-     * @return The {@code String} representation
-     */
-    @Override
-    public String toString() {
-        switch(this){
-            case NOTUSED:
-                return "NOTUSED";
-            case ORR :
-                return "ORR";
-            case ANDD:
-                return "ANDD";
-        }
-        throw new IllegalArgumentException("Couldn't find a String represent of the given enum");
-    }
 }

--- a/src/main/java/utilities/IOHandler.java
+++ b/src/main/java/utilities/IOHandler.java
@@ -56,13 +56,7 @@ public class IOHandler {
                 String[] splitLine = line.split(" ");
 
                 for (int j = 0; j < splitLine.length; j++) {
-                    if (Connectors.ANDD.toString().equals(splitLine[j])) {
-                        connectors[i][j] = Connectors.ANDD;
-                    } else if (Connectors.ORR.toString().equals(splitLine[j])) {
-                        connectors[i][j] = Connectors.ORR;
-                    } else if (Connectors.NOTUSED.toString().equals(splitLine[j])) {
-                        connectors[i][j] = Connectors.NOTUSED;
-                    }
+                    connectors[i][j] = Connectors.valueOf(splitLine[j]);
                 }
             }
 


### PR DESCRIPTION
Since we can use the `valueOf` function to get the String representation of the enums in Connectors there is no need for its toString method. The method has therefore been removed and IOHandler has been updated to reflect these changes.