### PR TITLE
feat/#88 Exclude the Main class from the CodeCov analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "src/main/java/decide/Connectors.java"
+  - "src/main/java/Main.java"


### PR DESCRIPTION
Exclude the `Main` class from the CodeCov analysis. 